### PR TITLE
Authorize Vagrant SSH key-based access

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,10 +2,6 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-#   config.ssh.insert_key = false
-  # TODO: Remove, once Hashicorp Vagrant SSH key is added
-  config.ssh.username = 'vagrant'
-  config.ssh.password = 'vagrant'
   config.vm.synced_folder '.', '/vagrant'
 
   # VirtualBox.

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eux
+###
+## Install Vagrant Hashicorp SSH Key
+## This way Vagrant can auth via known SSH key + user combination
+###
+
+echo 'Authorizing Vagrant SSH key-based access ...'
+
+mkdir -pm 700 /home/vagrant/.ssh
+curl --retry 3 --insecure --location "https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub" > /home/vagrant/.ssh/authorized_keys
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/st2.json
+++ b/st2.json
@@ -11,7 +11,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sudo -S -E bash -eu '{{.Path}}'",
       "scripts": [
-        "scripts/pre_cleanup.sh"
+        "scripts/pre_cleanup.sh",
+        "scripts/vagrant.sh"
       ]
     },
     {


### PR DESCRIPTION
Closes #4 

Vagrant needs a known SSH key to be authorized to be able to login to the box.
See: https://github.com/hashicorp/vagrant/tree/master/keys for more info.
