### PR TITLE
Add a 'box' Vagrantfile template

### DIFF
--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -1,0 +1,57 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Custom Vagrantfile shipped with the box.
+# For more info about the original Vagrantfile load-order-merge mechanism see:
+# - https://groups.google.com/forum/#!topic/packer-tool/Iu1jSRgbWOk
+# - https://www.vagrantup.com/docs/cli/package.html
+# - https://www.vagrantup.com/docs/vagrantfile/#load-order
+
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  config.vm.name = "stackstorm"
+  config.vm.box = "stackstorm/st2"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # VirtualBox.
+  # `vagrant up virtualbox --provider=virtualbox`
+  config.vm.define "virtualbox" do |virtualbox|
+    virtualbox.vm.hostname = "stackstorm"
+
+    config.vm.provider :virtualbox do |vb|
+      vb.name = "stackstorm"
+      vb.gui = false
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+    config.vm.provision "shell", inline: "st2 --version"
+  end
+end

--- a/st2.json
+++ b/st2.json
@@ -94,7 +94,8 @@
   "post-processors": [
     {
       "output": "builds/{{user `vm_name`}}-v{{user `st2_version`}}_{{timestamp}}.box",
-      "type": "vagrant"
+      "type": "vagrant",
+      "vagrantfile_template": "Vagrantfile.template"
     }
   ]
 }


### PR DESCRIPTION
This Vagrantfile is shipped with the box (bundled into an image) and used after unpacking the box during `vagrant` commands.

For more info about the original Vagrantfile load-order-merge mechanism see:
- https://groups.google.com/forum/#!topic/packer-tool/Iu1jSRgbWOk
- https://www.vagrantup.com/docs/cli/package.html
- https://www.vagrantup.com/docs/vagrantfile/#load-order

It's a bit complicated.