### PR TITLE
Establish box Versioning format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/*
 
 .DS_Store
 builds/*.box
+builds/*.ova

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -7,7 +7,7 @@
 echo 'Authorizing Vagrant SSH key-based access ...'
 
 mkdir -pm 700 /home/vagrant/.ssh
-curl --retry 3 --insecure --location "https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub" > /home/vagrant/.ssh/authorized_keys
+curl --retry 3 --insecure --silent --show-error --location "https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub" > /home/vagrant/.ssh/authorized_keys
 chmod 0600 /home/vagrant/.ssh/authorized_keys
 chown -R vagrant:vagrant /home/vagrant/.ssh
 chmod -R go-rwsx /home/vagrant/.ssh

--- a/st2.json
+++ b/st2.json
@@ -1,6 +1,7 @@
 {
   "variables": {
     "st2_version": "2.7.1",
+    "box_version": "{{isotime \"20060102\"}}",
     "st2_user": "st2admin",
     "st2_password": "Ch@ngeMe",
     "vm_name": "st2",
@@ -93,7 +94,7 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{user `vm_name`}}-v{{user `st2_version`}}_{{timestamp}}.box",
+      "output": "builds/{{user `vm_name`}}_v{{user `st2_version`}}-{{user `box_version`}}.box",
       "type": "vagrant"
     }
   ]

--- a/st2.json
+++ b/st2.json
@@ -95,7 +95,15 @@
   "post-processors": [
     {
       "output": "builds/{{user `vm_name`}}_v{{user `st2_version`}}-{{user `box_version`}}.box",
-      "type": "vagrant"
+      "type": "vagrant",
+      "keep_input_artifact": true
+    },
+    {
+      "type": "shell-local",
+      "inline": [
+        "mv output-virtualbox-iso/{{user `vm_name`}}.ova builds/{{user `vm_name`}}_v{{user `st2_version`}}-{{user `box_version`}}.ova",
+        "rm -rf output-virtualbox-iso/"
+      ]
     }
   ]
 }


### PR DESCRIPTION

- Establish the Vagrant & OVA box versioning format
  - `v2.7.1-20180501` is the version format we'll follow for now (and include in CHANGELOG)
     - Conforms with the https://semver.org/
     - `v2.7.1` works as a version
     - `20180501` works as a revision (in our case the image generation date)
- Generate & ship `.ova` in the same `./build` directory, apart of `.box` file

Correct versioning will help to upload .box to the Vagrant cloud & follow the ordering.