### PR TITLE
Add StackStorm integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 * Initial release with minimally working StackStorm Vagrant box, created from Packer build pipeline
 * Add first system Vagrant-focused integration tests, tie them with the build (#5)
 * Add custom MOTD/welcome message after logging in to console (#15)
+* Add StackStorm infrastructure integration tests, ship with new `st2-integration-tests` executable available to user (#20)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ To make testing close to a real-world scenario, an additional VM reboot step in 
 
 ### `st2-integration-tests`
 From a user's standpoint, for easier StackStorm troubleshooting there is an `st2-integration-tests` executable shipped in sbin/PATH.<br>
-Sometimes StackStorm is not running properly by some reason.
-Finding an answer is a responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
+Sometimes StackStorm does not run properly for some reason.
+Discovering why is the responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
 This can save time for both user & engineering team to avoid extensive troubleshooting steps.
 
 If something went wrong, - just ask them to run `st2-integration-tests`!

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ To make testing close to a real-world scenario, an additional VM reboot step in 
 
 > Please don't forget to include respective tests for every new critical feature of the system!<br>
 > See https://www.inspec.io/docs/reference/dsl_inspec/ and existing `/tests` examples which makes easy to add more tests.
+
+### `st2-integration-tests`
+From a user's standpoint, for easier StackStorm troubleshooting there is an `st2-integration-tests` executable shipped in sbin/PATH.<br>
+Sometimes StackStorm is not running properly by some reason.
+Finding an answer is a responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
+This can save time for both user & engineering team to avoid extensive troubleshooting steps.
+
+If something went wrong, - just ask them to run `st2-integration-tests`!

--- a/opt/bin/st2-integration-tests
+++ b/opt/bin/st2-integration-tests
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo -e '\033[1;38;5;208mRunning StackStorm Integration Tests ...\033[0m'
+
+sudo inspec exec --show-progress /opt/ova/test/integration/2-stackstorm
+
+retval=$?
+if [ $retval -ne 0 ]; then
+  echo
+  echo -e '\033[1;31mStackStorm Integration Tests failed!\033[0m'
+  echo -e '\033[1;31mSee the error above for more info.\033[0m'
+  echo
+  echo "If you believe it's by mistake, please report to:"
+  echo 'https://github.com/stackstorm/packer-st2/issues'
+fi
+exit $retval

--- a/scripts/st2-integration-tests.sh
+++ b/scripts/st2-integration-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+echo -e '\033[33mAdd "st2-integration-tests" tool to PATH ...\033[0m'
+ln -sf /opt/ova/bin/st2-integration-tests /usr/local/sbin/st2-integration-tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,6 +18,6 @@ for dir in */; do
   dir=$(basename $dir)
   if [ -f "${dir}/inspec.yml" ]; then
     echo -e "\nRunning tests for \033[1;36m${dir}\033[0m ..."
-    sudo inspec exec ${dir}
+    sudo inspec exec --show-progress ${dir}
   fi
 done

--- a/test/integration/2-stackstorm/controls/mongodb_test.rb
+++ b/test/integration/2-stackstorm/controls/mongodb_test.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'mongodb' do
+  title 'Database availability check'
+  desc '
+    Ensure that MongoDB is installed, bindng on network ports and actually works & available.
+  '
+
+  describe package 'mongodb-org' do
+    it { should be_installed }
+  end
+
+  describe file('/etc/mongod.conf') do
+    it { should exist }
+  end
+
+  describe yaml('/etc/mongod.conf') do
+    # Security auth should be enabled for mongo
+    # @link: https://github.com/StackStorm/st2-packages/blob/a93701d98a130f50f7cb551e842889212ece3b11/scripts/st2bootstrap-deb.sh#L483-L484
+    its(['security','authorization']) { should eq 'enabled' }
+
+    # Mongo should listen on localhost only
+    # @link: https://github.com/StackStorm/st2-packages/blob/a93701d98a130f50f7cb551e842889212ece3b11/scripts/st2bootstrap-deb.sh#L446-L447
+    its(['net','bindIp']) { should eq '127.0.0.1' }
+    its(['net','port']) { should eq 27017 }
+  end
+
+  describe service('mongod') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port(27017) do
+    it { should be_listening }
+    its('processes') { should include 'mongod' }
+    its('addresses') { should eq ['127.0.0.1'] }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  # TODO: Security check that 'mongod' is not listening on any other ports & IPs
+end

--- a/test/integration/2-stackstorm/controls/rabbitmq_test.rb
+++ b/test/integration/2-stackstorm/controls/rabbitmq_test.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'rabbitmq' do
+  title 'MQ availability check'
+  desc '
+    Ensure that RabbitMQ is installed, bindng on network ports and has specific configuration set.
+  '
+
+  describe package 'rabbitmq-server' do
+    it { should be_installed }
+  end
+
+  describe file('/etc/rabbitmq/rabbitmq-env.conf') do
+    it { should exist }
+    # RabbitMQ should listen on localhost only
+    # @link: https://github.com/StackStorm/st2-packages/blob/a93701d98a130f50f7cb551e842889212ece3b11/scripts/st2bootstrap-deb.sh#L425-L426
+    its('content') { should match /^RABBITMQ_NODE_IP_ADDRESS=127.0.0.1$/ }
+  end
+
+  describe service('rabbitmq-server') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port(5672) do
+    it { should be_listening }
+    its('processes') { should include 'beam.smp' }
+    its('addresses') { should eq ['127.0.0.1'] }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  # TODO: Security check that 'beam.smp' is not listening on any other ports & IPs
+end

--- a/test/integration/2-stackstorm/controls/repository_test.rb
+++ b/test/integration/2-stackstorm/controls/repository_test.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2-repo' do
+  title 'StackStorm apt repository check'
+  desc '
+    Ensure that stackstorm apt package repository is installed, enabled and actually works.
+  '
+
+  describe file '/etc/apt/sources.list.d/StackStorm_stable.list' do
+    it { should exist }
+  end
+
+  describe apt('https://packagecloud.io/StackStorm/stable/ubuntu/') do
+    it { should exist }
+    it { should be_enabled }
+  end
+end

--- a/test/integration/2-stackstorm/controls/services_test.rb
+++ b/test/integration/2-stackstorm/controls/services_test.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+# List of available `st2` services:
+# https://github.com/StackStorm/st2/blob/master/st2common/bin/st2ctl#L5
+ST2_SERVICES = %w(
+  st2actionrunner st2api st2stream
+  st2auth st2garbagecollector st2notifier
+  st2resultstracker st2rulesengine st2sensorcontainer
+).freeze
+
+control 'st2-services' do
+  title 'verify stackstorm services'
+  desc '
+    Ensure that stackstorm services are shipped, enabled, started and listening on network ports.
+  '
+
+  ST2_SERVICES.each do |service_name|
+    describe service(service_name) do
+      it { should be_installed }
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+
+  # st2auth
+  describe port(9100) do
+    it { should be_listening }
+    its('addresses') { should include '127.0.0.1' }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  # st2api
+  describe port(9101) do
+    it { should be_listening }
+    its('addresses') { should include '127.0.0.1' }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  # st2stream
+  describe port(9102) do
+    it { should be_listening }
+    its('addresses') { should include '127.0.0.1' }
+    its('protocols') { should cmp 'tcp' }
+  end
+end

--- a/test/integration/2-stackstorm/controls/st2-actions_test.rb
+++ b/test/integration/2-stackstorm/controls/st2-actions_test.rb
@@ -1,0 +1,30 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2-actions' do
+  title 'Ensure st2 actions are working'
+  desc '
+    Check that st2 run and st2 pack commands are executing successfully.
+  '
+
+  describe command("st2 pack install st2") do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+
+  # Sudo really works
+  describe command("st2 run core.local_sudo id") do
+    its(:exit_status) { is_expected.to eq 0 }
+    its(:stdout) { should match /root/ }
+  end
+
+  # Check that UTF-8 locale is passed through
+  describe command("st2 run core.local cmd=locale") do
+    its(:stdout) { should match /UTF-8/ }
+  end
+
+  # Check that 'st2 run' can handle unicode in action params
+  command("st2 run core.local cmd=\"echo '¯\_(ツ)_/¯'\"") do
+    its(:exit_status) { is_expected.to eq 0 }
+  end
+end

--- a/test/integration/2-stackstorm/controls/st2_test.rb
+++ b/test/integration/2-stackstorm/controls/st2_test.rb
@@ -1,0 +1,48 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2' do
+  title 'Package integrity check'
+  desc '
+    Ensure st2 package integrity: its installed and shipped
+    with the expected directories, files and correct permissions.
+  '
+
+  describe package 'st2' do
+    it { should be_installed }
+  end
+
+  describe group('st2') do
+    it { should exist }
+  end
+
+  describe user('st2') do
+    it { should exist }
+    its('group') { should eq 'st2' }
+  end
+
+  describe directory('/etc/st2') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file('/etc/st2/st2.conf') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file('/etc/st2/htpasswd') do
+    it { should exist }
+    its('owner') { should eq 'st2' }
+    its('group') { should eq 'st2' }
+    it { should be_readable.by('owner') }
+    it { should be_writable.by('owner') }
+    it { should_not be_readable.by('group') }
+    it { should_not be_writable.by('group') }
+    it { should_not be_executable.by('owner') }
+    it { should_not be_executable.by('group') }
+  end
+end

--- a/test/integration/2-stackstorm/controls/st2chatops_test.rb
+++ b/test/integration/2-stackstorm/controls/st2chatops_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2chatops' do
+  title 'Minimal package integrity check'
+  desc '
+    Basic check that st2chatops package is installed. Not doing any further tests, since st2chatops
+    requires correct hubot adapter settings to be configured for running.
+  '
+
+  describe package('st2chatops') do
+    it { should be_installed }
+  end
+
+  describe service('st2chatops') do
+    it { should be_installed }
+    it { should be_enabled }
+  end
+
+  describe file('/opt/stackstorm/chatops/st2chatops.env') do
+    it { should exist }
+  end
+end

--- a/test/integration/2-stackstorm/controls/st2web_test.rb
+++ b/test/integration/2-stackstorm/controls/st2web_test.rb
@@ -1,0 +1,100 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2web' do
+  title 'Integrity check'
+  desc '
+    Check that st2web is installed, dependant service nginx is running with the correct st2.conf
+    web config, stackstorm REST API URL endpoints are available and Web UI actually works.
+  '
+
+  # Only one of the 2 expressions should succeed
+  describe.one do
+    describe package('st2web') do
+      it { should be_installed }
+    end
+    describe package('bwc-ui') do
+      it { should be_installed }
+    end
+  end
+
+  # TODO: Extract nginx rules into a separated control
+  describe package('nginx') do
+    it { should be_installed }
+  end
+
+  # nginx version should be >= '1.7.5' for st2web to work
+  describe nginx do
+    its('version') { should cmp >= '1.7.5' }
+  end
+
+  describe service('nginx') do
+    it { should be_installed }
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  describe port(80) do
+    it { should be_listening }
+    its('processes') { should include 'nginx' }
+    its('addresses') { should include '0.0.0.0' }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  describe port(443) do
+    it { should be_listening }
+    its('processes') { should include 'nginx' }
+    its('addresses') { should include '0.0.0.0' }
+    its('protocols') { should cmp 'tcp' }
+  end
+
+  describe directory('/etc/ssl/st2') do
+    it { should exist }
+    its('owner') { should eq 'root' }
+    its('group') { should eq 'root' }
+  end
+
+  describe file('/etc/ssl/st2/st2.crt') do
+    it { should exist }
+  end
+
+  describe file('/etc/ssl/st2/st2.key') do
+    it { should exist }
+  end
+
+  describe x509_certificate('/etc/ssl/st2/st2.crt') do
+    its('validity_in_days') { should be > 90 }
+  end
+
+  describe file('/etc/nginx/conf.d/st2.conf') do
+    it { should exist }
+  end
+
+  # TODO: redo with https://www.inspec.io/docs/reference/resources/nginx_conf/
+  # Doesn't work now
+  # describe nginx_conf.http do
+  # should match: include /etc/nginx/conf.d/*.conf;
+  # end
+
+  describe file('/etc/nginx/nginx.conf') do
+    its('content') { should match 'include /etc/nginx/conf.d/\*.conf;' }
+  end
+
+  describe http('http://localhost/', enable_remote_worker: true) do
+    its('status') { should eq 301 }
+  end
+
+  describe http('https://localhost/', ssl_verify: false, enable_remote_worker: true) do
+    its('status') { should cmp 200 }
+    its('body') { should match /st2constants/ }
+  end
+
+  # StackStorm API URL endpoints check, defined in nginx
+  %w(api auth stream).each do |service|
+    describe http("https://localhost/#{service}/", ssl_verify: false, enable_remote_worker: true) do
+      its('headers.content-type') { should cmp 'application/json' }
+      its('headers.access-control-allow-headers') { should match /St2-Api-Key/ }
+    end
+  end
+end

--- a/test/integration/2-stackstorm/controls/stanley_test.rb
+++ b/test/integration/2-stackstorm/controls/stanley_test.rb
@@ -1,0 +1,81 @@
+# encoding: utf-8
+# The Inspec reference, with examples and extensive documentation, can be
+# found at https://docs.chef.io/inspec_reference.html
+
+control 'st2-user' do
+  title 'stanley system user check'
+  desc '
+    Check that st2 system user (default is stanley) is added, exists, enabled in sudoers
+    and has the SSH keys generated with correct file permissions and is authorized.
+  '
+
+  describe group('stanley') do
+    it { should exist }
+  end
+
+  describe user('stanley') do
+    it { should exist }
+    its('group') { should eq 'stanley' }
+    its('home') { should eq '/home/stanley' }
+  end
+
+  describe passwd.users(/stanley/) do
+    its('homes') { should eq ['/home/stanley'] }
+  end
+
+  describe directory('/home/stanley/.ssh') do
+    it { should exist }
+    its('owner') { should eq 'stanley' }
+    its('group') { should eq 'stanley' }
+    it { should be_readable.by('owner') }
+    it { should_not be_readable.by('group') }
+    it { should be_writable.by('owner') }
+    it { should_not be_writable.by('group') }
+    it { should be_executable.by('owner') }
+    it { should_not be_executable.by('group') }
+  end
+
+  describe file('/home/stanley/.ssh/stanley_rsa') do
+    it { should exist }
+    its('owner') { should eq 'stanley' }
+    its('group') { should eq 'stanley' }
+    it { should be_readable.by('owner') }
+    it { should_not be_readable.by('group') }
+    it { should_not be_readable.by('other') }
+    it { should be_writable.by('owner') }
+    it { should_not be_writable.by('group') }
+    it { should_not be_writable.by('other') }
+    it { should_not be_executable }
+  end
+
+  describe file('/home/stanley/.ssh/stanley_rsa.pub') do
+    it { should exist }
+    its('owner') { should eq 'stanley' }
+    its('group') { should eq 'stanley' }
+    it { should be_readable.by('owner') }
+    it { should be_readable.by('group') }
+    it { should be_readable }
+    it { should be_writable.by('owner') }
+    it { should_not be_writable.by('group') }
+    it { should_not be_executable.by('owner') }
+    it { should_not be_executable.by('group') }
+  end
+
+  describe file('/home/stanley/.ssh/authorized_keys') do
+    it { should exist }
+    its('owner') { should eq 'stanley' }
+    its('group') { should eq 'stanley' }
+    it { should be_readable.by('owner') }
+    it { should_not be_readable.by('group') }
+    it { should_not be_readable.by('other') }
+    it { should be_writable.by('owner') }
+    it { should_not be_writable.by('group') }
+    it { should_not be_writable.by('other') }
+    it { should_not be_executable }
+  end
+
+  describe file('/etc/sudoers.d/st2') do
+    it { should exist }
+    its('content') { should match(%r{stanley\s.*?ALL\=\(ALL\)\s.*?NOPASSWD:\s.*?SETENV:\s.*?ALL}) }
+  end
+end

--- a/test/integration/2-stackstorm/inspec.lock
+++ b/test/integration/2-stackstorm/inspec.lock
@@ -1,0 +1,3 @@
+---
+lockfile_version: 1
+depends: []

--- a/test/integration/2-stackstorm/inspec.yml
+++ b/test/integration/2-stackstorm/inspec.yml
@@ -1,0 +1,14 @@
+name: stackstorm
+title: Integration Tests for StackStorm community
+summary: >
+  Tests to verify if StackStorm packages st2, st2web, st2mistral, st2chatops are installed,
+  files and directories are shipped, services are running as well as dependent servers like
+  nginx, postgresql, mongodb are available and working correctly.
+maintainer: StackStorm
+copyright: StackStorm
+copyright_email: info@stackstorm.com
+license: Apache-2.0
+version: 0.1.0
+supports:
+  - os-name: ubuntu
+    release: 16.04


### PR DESCRIPTION
Closes #6 

Back-port StackStorm InSpec tests from the previous OVA work.

Add `st2-integration-tests` executable shipped in sbin/PATH so users could run that in case when stackstorm is "not working" for some reason and get report back from the tool about what went wrong (like issues with mongo, rabbit, stackstorm services, etc).