### PR TITLE
Getting the initial demo release out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 * Add first system Vagrant-focused integration tests, tie them with the build (#5)
 * Add custom MOTD/welcome message after logging in to console (#15)
 * Add StackStorm infrastructure integration tests, ship with new `st2-integration-tests` executable available to user (#20)
-* Install Virtualbox guest additions
+* Install Virtualbox guest additions (#22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## In Development
+
+## v2.7.1-20180507
 * Initial release with minimally working StackStorm Vagrant box, created from Packer build pipeline
 * Add first system Vagrant-focused integration tests, tie them with the build (#5)
 * Add custom MOTD/welcome message after logging in to console (#15)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # packer-st2
 Packer templates for building Vagrant box with [StackStorm](https://github.com/stackstorm/st2) community installed
 
-## Building Vagrant & OVA
+## Usage
+```
+vagrant init stackstorm/st2
+vagrant up
+```
 
+### `st2-integration-tests`
+Sometimes StackStorm does not run properly for some reason.
+Discovering why is the responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
+This can save time for both user & engineering team to avoid extensive troubleshooting steps.
+
+If something went wrong, - just run `st2-integration-tests`!
+
+## Building Vagrant & OVA
 ### Requirements
 The following tools are required for the build process:
 - Virtualbox - https://www.virtualbox.org/wiki/Downloads
 - Packer - https://www.packer.io/downloads.html (`make install-packer`)
-
 
 ### Build Steps
 * Run Packer via `make build`
@@ -23,11 +34,3 @@ To make testing close to a real-world scenario, an additional VM reboot step in 
 
 > Please don't forget to include respective tests for every new critical feature of the system!<br>
 > See https://www.inspec.io/docs/reference/dsl_inspec/ and existing `/tests` examples which makes easy to add more tests.
-
-### `st2-integration-tests`
-From a user's standpoint, for easier StackStorm troubleshooting there is an `st2-integration-tests` executable shipped in sbin/PATH.<br>
-Sometimes StackStorm does not run properly for some reason.
-Discovering why is the responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
-This can save time for both user & engineering team to avoid extensive troubleshooting steps.
-
-If something went wrong, - just ask them to run `st2-integration-tests`!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Download from Vagrant Cloud](https://img.shields.io/badge/Vagrant-cloud%20%E2%86%92-1563ff.svg)](https://app.vagrantup.com/stackstorm/boxes/st2/)
 
 [Packer](https://www.packer.io/intro/index.html) templates with [InSpec](https://www.inspec.io/) integration tests for building Vagrant box & OVA image with [StackStorm](https://github.com/stackstorm/st2) community installed.
-A fully tested and packaged artifacts are produced during the build pipeline.
+Fully tested and packaged artifacts are produced during the build pipeline.
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Starting a Vagrant VM is easy:
 ```
 vagrant init stackstorm/st2
 vagrant up
+vagrant ssh
 ```
 
 ### Updating the Vagrant box

--- a/README.md
+++ b/README.md
@@ -1,18 +1,46 @@
-# packer-st2
-Packer templates for building Vagrant box with [StackStorm](https://github.com/stackstorm/st2) community installed
+# StackStorm Vagrant & OVA
+[![Latest Release](https://img.shields.io/github/release/StackStorm/packer-st2/all.svg)](https://github.com/StackStorm/packer-st2/releases)
+[![Download from Vagrant Cloud](https://img.shields.io/badge/Vagrant-cloud%20%E2%86%92-1563ff.svg)](https://app.vagrantup.com/stackstorm/boxes/st2/)
+
+[Packer](https://www.packer.io/intro/index.html) templates with [InSpec](https://www.inspec.io/) integration tests for building Vagrant box & OVA image with [StackStorm](https://github.com/stackstorm/st2) community installed.
+A fully tested and packaged artifacts are produced during the build pipeline.
+
 
 ## Usage
+### Vagrant Quick Start
+Starting a Vagrant VM is easy:
 ```
 vagrant init stackstorm/st2
 vagrant up
 ```
 
+### Updating the Vagrant box
+Once we release a newer version, Vagrant will warn you about the available update. To update the box:
+```
+vagrant box outdated
+vagrant box remove stackstorm/st2
+vagrant up
+```
+
+### OVA Virtual Appliance
+Virtual appliance is available for download as `.OVA` image from the [Github Releases](https://github.com/StackStorm/packer-st2/releases) page.<br>
+> _Linux login credentials:_<br>
+> Username: `vagrant`<br>
+> Password: `vagrant`
+>
+> _StackStorm login details:_<br>
+> Username: `st2admin`<br>
+> Password: `Ch@ngeMe`
+
+At the moment only Virtualbox provider is supported. VMWare-compatible virtual appliance is available with [StackStorm Enterprise (EWC)](https://stackstorm.com/#product) image. Ask [StackStorm Support](mailto:support@stackstorm.com) for more info.
+
 ### `st2-integration-tests`
-Sometimes StackStorm does not run properly for some reason.
-Discovering why is the responsibility of `st2-integration-tests` which will run StackStorm InSpec Tests and report back with more detailed info.
+Sometimes StackStorm does not run properly for some reason.<br>
+Discovering why at a infra level is the responsibility of `st2-integration-tests` which will perform StackStorm InSpec Tests and report back with more detailed info.<br>
 This can save time for both user & engineering team to avoid extensive troubleshooting steps.
 
 If something went wrong, - just run `st2-integration-tests`!
+
 
 ## Building Vagrant & OVA
 ### Requirements
@@ -26,6 +54,7 @@ The following tools are required for the build process:
 The Packer build process will import `Ubuntu 16.04 Xenial Server` iso image in Virtualbox, bootstrap Ubuntu server with all the required settings (automating typical iso live CD install steps),
 install & configure StackStorm and finally export both the Vagrant box and .OVA image into the [`/builds`](/builds) directory.
 > See [`st2.json`](/st2.json) which codifies Packer build pipeline and could be used as a source of entire automation logic.
+
 
 ## Testing
 [`/test`](/test) directory contains Integration tests, powered by [InSpec.io](https://www.inspec.io/) Infrastructure Testing framework.

--- a/st2.json
+++ b/st2.json
@@ -27,7 +27,8 @@
         "scripts/pre_cleanup.sh",
         "scripts/vagrant.sh",
         "scripts/welcome.sh",
-        "scripts/virtualbox.sh"
+        "scripts/virtualbox.sh",
+        "scripts/st2-integration-tests.sh"
       ]
     },
     {


### PR DESCRIPTION
First _manual_ demo release.

We don't have CI/CD yet (see issues in #17, #21 and TBD #10, #11), so everything is done by hand for the initial demo release to show basic idea how Community Vagrant/OVA works.
