### PR TITLE
Deploy artifacts to github releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,9 @@ workflows:
               only:
                 - master
                 - feature/deploy-releases
+            tags:
+              only:
+                - /^v.*/
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,12 +182,21 @@ workflows:
           requires:
             - packer-lint
             - inspec-lint
+          filters:
+            tags:
+              only: /.*/
       - provision-metal:
           requires:
             - create-metal
+          filters:
+            tags:
+              only: /.*/
       - build-test-ova:
           requires:
             - provision-metal
+          filters:
+            tags:
+              only: /.*/
       - destroy-metal:
           requires:
             - build-test-ova
@@ -195,6 +204,9 @@ workflows:
           requires:
             - build-test-ova
           filters:
+            branches:
+              ignore:
+                - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+-\d{8}$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,26 +177,14 @@ workflows:
   packer-st2:
     jobs:
       - packer-lint:
-          filters:
-            tags:
-              only: /.*/
       - inspec-lint:
-          filters:
-            tags:
-              only: /.*/
       - create-metal:
           requires:
             - packer-lint
             - inspec-lint
-          filters:
-            tags:
-              only: /.*/
       - provision-metal:
           requires:
             - create-metal
-          filters:
-            tags:
-              only: /.*/
       - build-test-ova:
           requires:
             - provision-metal
@@ -206,9 +194,6 @@ workflows:
       - destroy-metal:
           requires:
             - build-test-ova
-          filters:
-            tags:
-              only: /.*/
       - deploy-ova:
           requires:
             - build-test-ova

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,8 @@ workflows:
                 - master
   packer-st2:
     jobs:
-      - packer-lint:
-      - inspec-lint:
+      - packer-lint
+      - inspec-lint
       - create-metal:
           requires:
             - packer-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,9 +204,6 @@ workflows:
           requires:
             - build-test-ova
           filters:
-            branches:
-              ignore:
-                - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+-\d{8}$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,13 +196,9 @@ workflows:
           requires:
             - build-test-ova
           filters:
-            branches:
-              only:
-                - master
-                - feature/deploy-releases
             tags:
               only:
-                - /^v.*/
+                - /^v\d+\.\d+\.\d+-\d{8}$/
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,9 @@ jobs:
       - attach_workspace:
           at: ~/ova
       - run:
+          name: Remove unnecessary files before deploy
+          command: rm builds/README.md builds/*.box
+      - run:
           name: Deploy to GitHub releases
           command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,9 @@ workflows:
       - destroy-metal:
           requires:
             - build-test-ova
+          filters:
+            tags:
+              only: /.*/
       - deploy-ova:
           requires:
             - build-test-ova

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ jobs:
           <<: *destroy_device
           when: on_fail
 
-  # TODO: In a future PR, deploy artifact to S3.
   deploy-ova:
     <<: *job_defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,14 @@ workflows:
                 - master
   packer-st2:
     jobs:
-      - packer-lint
-      - inspec-lint
+      - packer-lint:
+          filters:
+            tags:
+              only: /.*/
+      - inspec-lint:
+          filters:
+            tags:
+              only: /.*/
       - create-metal:
           requires:
             - packer-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/ova
+      - run:
+          name: Deploy to GitHub releases
+          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds
 
   # Destroy the created Packet.net bare metal device.
   destroy-metal:
@@ -196,7 +199,7 @@ workflows:
             branches:
               only:
                 - master
-                - test-deploy
+                - feature/deploy-releases
 
 experimental:
   notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
 
 workflows:
   version: 2
-  ova-cleanup:
+  packer-st2-cleanup:
     triggers:
       - schedule:
           cron: "0 0,12 * * *"
@@ -174,7 +174,7 @@ workflows:
             branches:
               only:
                 - master
-  ova:
+  packer-st2:
     jobs:
       - packer-lint
       - inspec-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,18 +176,7 @@ workflows:
                 - master
   packer-st2:
     jobs:
-      - packer-lint:
-          filters:
-            tags:
-              only: /.*/
-      - inspec-lint:
-          filters:
-            tags:
-              only: /.*/
       - create-metal:
-          requires:
-            - packer-lint
-            - inspec-lint
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,11 +176,11 @@ workflows:
                 - master
   packer-st2:
     jobs:
-      - packer-lint
+      - packer-lint:
           filters:
             tags:
               only: /.*/
-      - inspec-lint
+      - inspec-lint:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,13 @@ workflows:
   packer-st2:
     jobs:
       - packer-lint
+          filters:
+            tags:
+              only: /.*/
       - inspec-lint
+          filters:
+            tags:
+              only: /.*/
       - create-metal:
           requires:
             - packer-lint
@@ -200,13 +206,14 @@ workflows:
       - destroy-metal:
           requires:
             - build-test-ova
+          filters:
+            tags:
+              only: /.*/
       - deploy-ova:
           requires:
             - build-test-ova
           filters:
             tags:
-              ignore:
-                - /^.*/
               only:
                 - /^v\d+\.\d+\.\d+-\d{8}$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,8 @@ workflows:
             - build-test-ova
           filters:
             tags:
+              ignore:
+                - /^.*/
               only:
                 - /^v\d+\.\d+\.\d+-\d{8}$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
     docker:
       - image: hashicorp/packer
     steps:
-      - checkout
       - run:
           name: Install dependencies
-          command: apk add --update make curl
+          command: apk add --update make curl git
+      - checkout
       - run:
           name: Packer Lint Check
           command: make validate
@@ -36,6 +36,9 @@ jobs:
     docker:
       - image: chef/inspec:1
     steps:
+      - run:
+          name: Install dependencies
+          command: apk add --update git
       - checkout
       - run:
           name: Inspec Lint Check
@@ -176,7 +179,18 @@ workflows:
                 - master
   packer-st2:
     jobs:
+      - packer-lint:
+          filters:
+            tags:
+              only: /.*/
+      - inspec-lint:
+          filters:
+            tags:
+              only: /.*/
       - create-metal:
+          requires:
+            - packer-lint
+            - inspec-lint
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@
 # Default YAML anchor, re-used in all CircleCI jobs
 _job_defaults: &job_defaults
   working_directory: ~/ova
+  docker:
+    - image: st2opsadmin/ovabuild-circle
 
 # Re-used in jobs to terminate the Packet bare-metal device
 _destroy_device: &destroy_device
@@ -19,12 +21,7 @@ jobs:
   # Run Packer Lint checks for OVA json file
   packer-lint:
     <<: *job_defaults
-    docker:
-      - image: hashicorp/packer
     steps:
-      - run:
-          name: Install dependencies
-          command: apk add --update make curl git
       - checkout
       - run:
           name: Packer Lint Check
@@ -33,12 +30,7 @@ jobs:
   # Run Inspec Lint checks for test files
   inspec-lint:
     <<: *job_defaults
-    docker:
-      - image: chef/inspec:1
     steps:
-      - run:
-          name: Install dependencies
-          command: apk add --update git
       - checkout
       - run:
           name: Inspec Lint Check
@@ -55,8 +47,6 @@ jobs:
   # Request creation of bare-metal server on Packet.net
   create-metal:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     steps:
       - checkout
       - run:
@@ -75,8 +65,6 @@ jobs:
   # Install the required software like Packer, Virtualbox, etc on bare-metal Packet.net server
   provision-metal:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     steps:
       - checkout
       - attach_workspace:
@@ -100,8 +88,6 @@ jobs:
   # Run an OVA build via Packer on bare-metal server
   build-test-ova:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     environment:
       HOSTALIASES: .circleci/ansible/.hosts
     steps:
@@ -127,8 +113,6 @@ jobs:
 
   deploy-ova:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     steps:
       - checkout
       - attach_workspace:
@@ -140,8 +124,6 @@ jobs:
   # Destroy the created Packet.net bare metal device.
   destroy-metal:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     steps:
       - checkout
       - attach_workspace:
@@ -153,8 +135,6 @@ jobs:
   # Destroy any packet.net bare metal devices running for more than an hour
   scrap-metal:
     <<: *job_defaults
-    docker:
-      - image: st2opsadmin/ovabuild-circle
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ jobs:
       - run:
           name: Fetch back the produced OVA image
           command: rsync -avz -e 'ssh -o StrictHostKeyChecking=no' root@metal:/home/ova/builds .
+      - run:
+          name: Remove unnecessary files before persisting and deploying
+          command: rm builds/README.md builds/*.box
       - store_artifacts:
           path: builds
           destination: .
@@ -117,9 +120,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/ova
-      - run:
-          name: Remove unnecessary files before deploy
-          command: rm builds/README.md builds/*.box
       - run:
           name: Deploy to GitHub releases
           command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,15 @@ workflows:
           requires:
             - packer-lint
             - inspec-lint
+          filters:
+            tags:
+              only: /.*/
       - provision-metal:
           requires:
             - create-metal
+          filters:
+            tags:
+              only: /.*/
       - build-test-ova:
           requires:
             - provision-metal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,9 @@ workflows:
           requires:
             - build-test-ova
           filters:
+            branches:
+              ignore:
+                - /.*/
             tags:
               only:
                 - /^v\d+\.\d+\.\d+-\d{8}$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Add continuous integration (#19)
+* Deploy tagged builds to GitHub releases (#25)
 
 ## v2.7.1-20180507
 * Initial release with minimally working StackStorm Vagrant box, created from Packer build pipeline

--- a/builds/README.md
+++ b/builds/README.md
@@ -1,1 +1,1 @@
-This directory will contain built Vagrant box files.
+This directory contains the ova file.


### PR DESCRIPTION
Closes #9.

**Remaining packer-st2 CI tasks**

 - [x] Add `GITHUB_TOKEN` to packer-st2 CircleCI environment
 - [x] Change `.circleci/config.yml` such that a non-tagged build will result in the `deploy-ova` job NOT being executed.
 - [x] Call `ghr` tool in `deploy-ova` job, providing `CIRCLE_PROJECT_USERNAME`, `CIRCLE_PROJECT_REPONAME` and `CIRCLE_TAG`.
 - [x] Change `.circleci/config.yml` such that a tagged build will result in the `deploy-ova` job being executed.

**Remaining test tasks**

 - [x] Test pushing a tag results in build artifacts being deployed to GitHub release page.