### PR TITLE
Set 'st2_version' and 'box_version' dynamically or use env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Add continuous integration (#19)
+* Add `ST2_VERSION` and `BOX_VERSION` ENV vars for version pinning (#26)
 
 ## v2.7.1-20180507
 * Initial release with minimally working StackStorm Vagrant box, created from Packer build pipeline

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 # Fetch latest stable release if 'ST2_VERSION' ENV var not set (ex: `2.7.1`)
 ST2_VERSION ?= $(shell curl --silent "https://api.github.com/repos/stackstorm/st2/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
 # Get today's date if 'BOX_VERSION' ENV var not set (ex: `20180507`)
-BOX_VERSION ?= $(shell date +%Y%m%d)
+BOX_VERSION ?= $(shell date -u +%Y%m%d)
 
 
 .PHONY: install-packer validate build clean

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ GIT ?= git
 CURL ?= curl
 SHELL := /bin/bash
 UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
+# Fetch latest stable release if 'ST2_VERSION' ENV var not set (ex: `2.7.1`)
+ST2_VERSION ?= $(shell curl --silent "https://api.github.com/repos/stackstorm/st2/releases/latest" | grep -Po '"tag_name": "v\K.*?(?=")')
+# Get today's date if 'BOX_VERSION' ENV var not set (ex: `20180507`)
+BOX_VERSION ?= $(shell date +%Y%m%d)
 
 
 .PHONY: install-packer validate build clean
@@ -26,7 +30,10 @@ validate: $(PACKER)
 	$(PACKER) validate st2.json
 
 build: $(PACKER)
-	$(PACKER) build st2.json
+	$(PACKER) build \
+	  -var 'st2_version=$(ST2_VERSION)' \
+	  -var 'box_version=$(BOX_VERSION)' \
+	  st2.json
 
 clean:
 	rm -rf tmp/*

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ install & configure StackStorm and finally export both the Vagrant box and .OVA 
 ### Build params
 There are environment variables you can pass to control the StackStorm version and box/image version.
 - `ST2_VERSION` - `x.y.z` format, like `2.7.1` (default: latest st2 version)
-- `BOX_VERSION` - `YYYYMMDD` format, like `20180131` (default: today's date)
+- `BOX_VERSION` - `YYYYMMDD` format, like `20180131` (default: today's date in UTC)
 
 As a result, Packer will generate the box with version `v2.7.1-20180131`.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ The Packer build process will import `Ubuntu 16.04 Xenial Server` iso image in V
 install & configure StackStorm and finally export both the Vagrant box and .OVA image into the [`/builds`](/builds) directory.
 > See [`st2.json`](/st2.json) which codifies Packer build pipeline and could be used as a source of entire automation logic.
 
+### Build params
+There are environment variables you can pass to control the StackStorm version and box/image version.
+- `ST2_VERSION` - `x.y.z` format, like `2.7.1` (default: latest st2 version)
+- `BOX_VERSION` - `YYYYMMDD` format, like `20180131` (default: today's date)
+
+As a result, Packer will generate the box with version `v2.7.1-20180131`.
 
 ## Testing
 [`/test`](/test) directory contains Integration tests, powered by [InSpec.io](https://www.inspec.io/) Infrastructure Testing framework.

--- a/st2.json
+++ b/st2.json
@@ -1,7 +1,7 @@
 {
   "variables": {
-    "st2_version": "2.7.1",
-    "box_version": "{{isotime \"20060102\"}}",
+    "st2_version": "{{env `ST2_VERSION`}}",
+    "box_version": "{{env `BOX_VERSION`}}",
     "st2_user": "st2admin",
     "st2_password": "Ch@ngeMe",
     "vm_name": "st2",


### PR DESCRIPTION
The PR adds the optional build params: environment variables could be passed to the build to control the StackStorm version and box/image version:
- env `ST2_VERSION` - `x.y.z` format, like `2.7.1` (default: fetch latest st2 stable release version if not set)
- env `BOX_VERSION` - `YYYYMMDD` format, like `20180131` (default: use today's date if not set)

This way we avoid hardcoding the versions and use ENV vars when the pinning is needed (for example when creating a GitHub release aka git tag like `v2.7.1-20180507`).

Nice to have: `ST2_VERSION` and `BOX_VERSION` format validation.

