### PR TITLE
Add `st2_deploy` build step to upload the box to Vagrant Cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 # PACKET_API_TOKEN
 # PACKET_PROJECT_ID
 # PACKET_SSH_PUB_KEY
+# VAGRANT_CLOUD_TOKEN
 
 # Default YAML anchor, re-used in all CircleCI jobs
 _job_defaults: &job_defaults
@@ -121,8 +122,11 @@ jobs:
       - attach_workspace:
           at: ~/ova
       - run:
-          name: Deploy to GitHub releases
+          name: Deploy OVA to GitHub releases
           command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds
+      - run:
+          name: Deploy BOX to Vagrant Cloud
+          command: make deploy
 
   # Destroy the created Packet.net bare metal device.
   destroy-metal:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@
 # PACKET_PROJECT_ID
 # PACKET_SSH_PUB_KEY
 # VAGRANT_CLOUD_TOKEN
+# GITHUB_TOKEN
 
 # Default YAML anchor, re-used in all CircleCI jobs
 _job_defaults: &job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,6 @@ jobs:
       - store_artifacts:
           path: builds
           destination: .
-      - run:
-          name: Remove unnecessary files before persisting and deploying
-          command: rm builds/README.md builds/*.box
       - persist_to_workspace:
           root: ~/ova
           paths:
@@ -123,7 +120,7 @@ jobs:
           at: ~/ova
       - run:
           name: Deploy OVA to GitHub releases
-          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds
+          command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds/*.ova
       - run:
           name: Deploy BOX to Vagrant Cloud
           command: make deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add continuous integration (#19)
 * Deploy tagged builds to GitHub releases (#25)
 * Add `ST2_VERSION` and `BOX_VERSION` ENV vars for version pinning (#26)
+* Create custom [`vagrant-cloud-standalone`](https://github.com/armab/packer-post-processor-vagrant-cloud-standalone) Packer post processor, `make deploy` to Vagrant Cloud (#27)
 
 ## v2.7.1-20180507
 * Initial release with minimally working StackStorm Vagrant box, created from Packer build pipeline

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ tmp/packer_$(PACKER_VERSION).zip:
 
 validate: $(PACKER)
 	$(PACKER) validate st2.json
+	$(PACKER) validate st2_deploy.json
 
 build: $(PACKER)
 	$(PACKER) build \

--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,12 @@ build: $(PACKER)
 	  -var 'box_version=$(BOX_VERSION)' \
 	  st2.json
 
+# Deploy the .box, produced during the `build` to Vagrant Cloud
+deploy: $(PACKER)
+	$(PACKER) build \
+	  -var 'st2_version=$(ST2_VERSION)' \
+	  -var 'box_version=$(BOX_VERSION)' \
+	  st2_deploy.json
+
 clean:
 	rm -rf tmp/*

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PACKER ?= ~/bin/packer
 PACKER_VERSION := 1.2.1
+VAGRANT_CLOUD_STANDALONE_VERSION := 0.1.2
 GIT ?= git
 CURL ?= curl
 SHELL := /bin/bash
@@ -36,8 +37,20 @@ build: $(PACKER)
 	  -var 'box_version=$(BOX_VERSION)' \
 	  st2.json
 
+# 'Vagrant-cloud-standalone' is a forked Packer post-processor plugin to deploy .box artifact to Vagrant Cloud
+install-vagrant-cloud-standalone: tmp/vagrant-cloud-standalone_$(VAGRANT_CLOUD_STANDALONE_VERSION).zip
+	mkdir -p ~/bin
+	unzip -o -d ~/bin $<
+	@echo Vagrant-cloud-standalone plugin $(VAGRANT_CLOUD_STANDALONE_VERSION) was successfully installed!
+tmp/vagrant-cloud-standalone_$(VAGRANT_CLOUD_STANDALONE_VERSION).zip:
+	curl -fsSLo $@ 'https://github.com/armab/packer-post-processor-vagrant-cloud-standalone/releases/download/v$(VAGRANT_CLOUD_STANDALONE_VERSION)/packer-post-processor-vagrant-cloud-standalone_$(UNAME)_amd64.zip'
+	@echo Downloaded new Vagrant-cloud-standalone version: $(VAGRANT_CLOUD_STANDALONE_VERSION)!
+# Install 'packer-post-processor-vagrant-cloud-standalone' only if it doesn't exist
+~/bin/packer-post-processor-vagrant-cloud-standalone:
+	@$(MAKE) install-vagrant-cloud-standalone
+
 # Deploy the .box, produced during the `build` to Vagrant Cloud
-deploy: $(PACKER)
+deploy: $(PACKER) ~/bin/packer-post-processor-vagrant-cloud-standalone
 	$(PACKER) build \
 	  -var 'st2_version=$(ST2_VERSION)' \
 	  -var 'box_version=$(BOX_VERSION)' \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ tmp/packer_$(PACKER_VERSION).zip:
 	curl -fsSLo $@ 'https://releases.hashicorp.com/packer/$(PACKER_VERSION)/packer_$(PACKER_VERSION)_$(UNAME)_amd64.zip'
 	@echo Downloaded new Packer version: $(PACKER_VERSION)!
 
-validate: $(PACKER)
+validate: $(PACKER) ~/bin/packer-post-processor-vagrant-cloud-standalone
 	$(PACKER) validate st2.json
 	$(PACKER) validate st2_deploy.json
 

--- a/st2.json
+++ b/st2.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "purpose": "Packer template for building StackStorm Vagrant '.box' & '.ova' Virtual Appliance",
     "st2_version": "{{env `ST2_VERSION`}}",
     "box_version": "{{env `BOX_VERSION`}}",
     "st2_user": "st2admin",

--- a/st2_deploy.json
+++ b/st2_deploy.json
@@ -1,0 +1,26 @@
+{
+  "variables": {
+    "purpose": "Packer template for deploying a .box artifact to Vagrant CLoud",
+    "st2_version": "{{env `ST2_VERSION`}}",
+    "box_version": "{{env `BOX_VERSION`}}",
+    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
+    "vm_name": "st2"
+  },
+  "builders": [
+    {
+      "type": "file",
+      "content": "Do nothing, Packer just requires at least one builder",
+      "target": "/dev/null"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant-cloud-standalone",
+      "access_token": "{{user `cloud_token`}}",
+      "box_tag": "stackstorm/st2",
+      "provider": "virtualbox",
+      "version": "{{user `st2_version`}}-{{user `box_version`}}",
+      "artifact": "builds/{{user `vm_name`}}_v{{user `st2_version`}}-{{user `box_version`}}.box"
+    }
+  ]
+}

--- a/st2_deploy.json
+++ b/st2_deploy.json
@@ -3,7 +3,7 @@
     "purpose": "Packer template for deploying a .box artifact to Vagrant CLoud",
     "st2_version": "{{env `ST2_VERSION`}}",
     "box_version": "{{env `BOX_VERSION`}}",
-    "cloud_token": "{{ env `ATLAS_TOKEN` }}",
+    "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
     "vm_name": "st2"
   },
   "builders": [


### PR DESCRIPTION
Closes #10 

Automation to deploy the `.box` to Vagrant Cloud https://app.vagrantup.com/stackstorm/boxes/st2.

Had to [fork](https://github.com/armab/packer-post-processor-vagrant-cloud-standalone) orignal `vagrant-cloud` post-pocessor plugin https://www.packer.io/docs/post-processors/vagrant-cloud.html to be able to run the deploy step separately having just the artifact file. Otherwise it requires entire virtualbox/vagrant Packer build pipeline.

