### PR TITLE
Expose st2web in Vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Fix Vagrant Cloud deploy step, caused by wrong 'file not exist' error (#31)
+* Expose StackStorm Vagrant access via IP `10.10.10.10` (#29)
 
 ## v2.7.1-20180511
 * Add continuous integration (#19)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,17 +7,9 @@ Vagrant.configure("2") do |config|
   # VirtualBox.
   # `vagrant up virtualbox --provider=virtualbox`
   config.vm.define "virtualbox" do |virtualbox|
-    virtualbox.vm.hostname = "stackstorm"
+    virtualbox.vm.hostname = "stackstorm-virtualbox"
     # TODO: Try to automatically find & use the latest box from the ./builds dir?
-    virtualbox.vm.box = "file://builds/st2-v2.7.0_1523648841.box"
-    virtualbox.vm.network :private_network, ip: "172.16.3.3"
-
-    config.vm.provider :virtualbox do |v|
-      v.gui = false
-      v.memory = 2048
-      v.cpus = 2
-    end
-    config.vm.provision "shell", inline: "st2 --version"
+    virtualbox.vm.box = "file://builds/st2_v2.7.0-1523648841.box"
   end
 
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
   # Expose access to StackStorm via IP
   config.vm.network :private_network,
     ip: "10.10.10.10",
-    netmask: "255.255.255.252"
+    netmask: "255.255.255.254"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -54,6 +54,23 @@ Vagrant.configure("2") do |config|
     vb.memory = 2048
     vb.cpus = 2
   end
+
+  # Show welcome message with st2web login instructions after VM startup
+  config.vm.post_up_message = <<WELCOME
+  ███████╗████████╗██████╗      ██████╗ ██╗  ██╗
+  ██╔════╝╚══██╔══╝╚════██╗    ██╔═══██╗██║ ██╔╝
+  ███████╗   ██║    █████╔╝    ██║   ██║█████╔╝
+  ╚════██║   ██║   ██╔═══╝     ██║   ██║██╔═██╗
+  ███████║   ██║   ███████╗    ╚██████╔╝██║  ██╗
+  ╚══════╝   ╚═╝   ╚══════╝     ╚═════╝ ╚═╝  ╚═╝
+
+  To access the Web UI, head to:
+    https://10.10.10.10/
+    Username: st2admin
+    Password: Ch@ngeMe
+
+  Thanks for trying StackStorm!
+WELCOME
 
   config.vm.provision "shell", inline: "st2 --version"
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -28,6 +28,12 @@ Vagrant.configure("2") do |config|
   # via 127.0.0.1 to disable public access
   # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
 
+  # Expose StackStorm Web UI via localhost:9000
+  config.vm.network "forwarded_port",
+    guest: 443, host: 9000,
+    host_ip: "127.0.0.1", id: "st2web",
+    auto_correct: true
+
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network "private_network", ip: "192.168.33.10"

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -72,5 +72,5 @@ Vagrant.configure("2") do |config|
   Thanks for trying StackStorm!
 WELCOME
 
-  config.vm.provision "shell", inline: "st2 --version"
+  config.vm.provision "shell", inline: "st2 --version", run: "always"
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -72,5 +72,9 @@ Vagrant.configure("2") do |config|
   Thanks for trying StackStorm!
 WELCOME
 
-  config.vm.provision "shell", inline: "st2 --version", run: "always"
+  # Show currently installed StackStorm version
+  config.vm.provision "st2-version",
+    type: "shell",
+    inline: "st2 --version",
+    run: "always"
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -28,15 +28,14 @@ Vagrant.configure("2") do |config|
   # via 127.0.0.1 to disable public access
   # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
 
-  # Expose StackStorm Web UI via localhost:9000
-  config.vm.network "forwarded_port",
-    guest: 443, host: 9000,
-    host_ip: "127.0.0.1", id: "st2web",
-    auto_correct: true
-
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Expose access to StackStorm via IP
+  config.vm.network :private_network,
+    ip: "10.10.10.10",
+    netmask: "255.255.255.252"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/builds/README.md
+++ b/builds/README.md
@@ -1,1 +1,1 @@
-This directory contains the ova file.
+This directory contains the build artifacts.


### PR DESCRIPTION
Closes #28 

Make StackStorm web UI available via ~`https://127.0.0.1:9000/`~ `https://10.10.10.10/` for the host machine.

### TODO:
- [x] Implementation
  - [x] Verify
- [x] Print access details to stdout via Vagrantfile/ruby
- [x] Update st2docs