### PR TITLE
Extract ST2_VERSION and BOX_VERSION from the release tags

### DIFF
--- a/.circleci/bin/build.py
+++ b/.circleci/bin/build.py
@@ -1,12 +1,17 @@
+import os
 from fabric.api import run
-from fabric.context_managers import cd
+from fabric.context_managers import cd, shell_env
 
 
 def build():
     """
-    Run the OVA build on remote host with Fabric.
+    Run the Packer build on remote host with Fabric.
+
+    Bypass 'ST2_VERSION' and 'BOX_VERSION' ENV vars.
 
     :return:
     """
     with cd('/home/ova'):
-        run('make build')
+        with shell_env(ST2_VERSION=os.environ.get('ST2_VERSION'),
+                       BOX_VERSION=os.environ.get('BOX_VERSION')):
+            run('make build')

--- a/.circleci/bin/build.py
+++ b/.circleci/bin/build.py
@@ -3,15 +3,23 @@ from fabric.api import run
 from fabric.context_managers import cd, shell_env
 
 
+def pass_env(*args):
+    """
+    By-pass non-empty ENV variables with their values for the input list.
+
+    :param args: List of ENV variables to include
+    :type args: ``list``
+    :return: ENV variables with values to bypass
+    :rtype: ``dict``
+    """
+    return {k: v for k,v in os.environ.items() if k in args and v is not ''}
+
+
 def build():
     """
     Run the Packer build on remote host with Fabric.
-
-    Bypass 'ST2_VERSION' and 'BOX_VERSION' ENV vars.
-
-    :return:
+    Bypass local ENV vars 'ST2_VERSION' and 'BOX_VERSION' to remote host.
     """
     with cd('/home/ova'):
-        with shell_env(ST2_VERSION=os.environ.get('ST2_VERSION'),
-                       BOX_VERSION=os.environ.get('BOX_VERSION')):
+        with shell_env(**pass_env('ST2_VERSION', 'BOX_VERSION')):
             run('make build')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          export "CIRCLE_TAG=v2.7.1-20180130"
+          export CIRCLE_TAG=v2.7.1-20180130
 
           if [ ! -z "$CIRCLE_TAG" ]; then
             echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)'" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,22 +18,14 @@ _destroy_device: &destroy_device
   working_directory: .circleci/ansible/
 
 # Extract and export 'ST2_VERSION' and 'BOX_VERSION' when 'CIRCLE_TAG' ENV var is set
-_split_circle_tag: &split_circle_tag
+_pin_version_on_release: &pin_version_on_release
   run:
-    name:
+    name: Pin 'ST2_VERSION' and 'BOX_VERSION' on tag release
     command: |
-      export CIRCLE_TAG=v2.7.1-20183001
       if [ ! -z "$CIRCLE_TAG" ]; then
         echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)')" >> $BASH_ENV
         echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
       fi
-
-      # Debug
-      . $BASH_ENV
-      echo "CIRCLE_TAG=$CIRCLE_TAG"
-      echo "ST2_VERSION=$ST2_VERSION"
-      echo "BOX_VERSION=$BOX_VERSION"
-      exit 1
 
 version: 2
 jobs:
@@ -42,7 +34,6 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - <<: *split_circle_tag
       - run:
           name: Packer Lint Check
           command: make validate
@@ -114,6 +105,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/ova
+      - <<: *pin_version_on_release
       - run:
           name: Build & Test OVA
           command: fab -f .circleci/bin/build.py -H metal build
@@ -137,6 +129,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/ova
+      - <<: *pin_version_on_release
       - run:
           name: Deploy OVA to GitHub releases
           command: ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_TAG} builds/*.ova

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,23 @@ _destroy_device: &destroy_device
   command: ansible-playbook -v -i inventory destroy.yml
   working_directory: .circleci/ansible/
 
+# Extract and export 'ST2_VERSION' and 'BOX_VERSION' when 'CIRCLE_TAG' ENV var is set
+_split_circle_tag: &split_circle_tag
+  run:
+    name:
+    command: |
+      export CIRCLE_TAG=v2.7.1-20183001
+      if [ ! -z "$CIRCLE_TAG" ]; then
+        echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)')" >> $BASH_ENV
+        echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
+      fi
+
+      # Debug
+      . $BASH_ENV
+      echo "CIRCLE_TAG=$CIRCLE_TAG"
+      echo "ST2_VERSION=$ST2_VERSION"
+      echo "BOX_VERSION=$BOX_VERSION"
+      exit 1
 
 version: 2
 jobs:
@@ -25,20 +42,7 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run: |
-          export CIRCLE_TAG=v2.7.1-20180130
-
-          if [ ! -z "$CIRCLE_TAG" ]; then
-            echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)')" >> $BASH_ENV
-            echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
-          fi
-
-          . $BASH_ENV
-
-          echo "CIRCLE_TAG=$CIRCLE_TAG"
-          echo "ST2_VERSION=$ST2_VERSION"
-          echo "BOX_VERSION=$BOX_VERSION"
-          exit 1
+      - <<: *split_circle_tag
       - run:
           name: Packer Lint Check
           command: make validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,15 @@ jobs:
   # Run Packer Lint checks for OVA json file
   packer-lint:
     <<: *job_defaults
+    environment:
+      ST2_VERSION: "{{ 'v2.7.1-20180130'.split('-')[0] }}"
+      BOX_VERSION: "{{ 'v2.7.1-20180130'.split('-')[1] }}"
     steps:
       - checkout
+      - run: |
+          echo "ST2_VERSION=$ST2_VERSION"
+          echo "BOX_VERSION=$BOX_VERSION"
+          exit 1
       - run:
           name: Packer Lint Check
           command: make validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ jobs:
   # Run Packer Lint checks for OVA json file
   packer-lint:
     <<: *job_defaults
-    environment:
-      CIRCLE_TAG: "v2.7.1-20180130"
     steps:
       - checkout
       - run: |
+          export "CIRCLE_TAG=v2.7.1-20180130"
+
           if [ ! -z "$CIRCLE_TAG" ]; then
             echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)'" >> $BASH_ENV
             echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
@@ -35,6 +35,7 @@ jobs:
 
           . $BASH_ENV
 
+          echo "CIRCLE_TAG=$CIRCLE_TAG"
           echo "ST2_VERSION=$ST2_VERSION"
           echo "BOX_VERSION=$BOX_VERSION"
           exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,17 @@ jobs:
   packer-lint:
     <<: *job_defaults
     environment:
-      ST2_VERSION: "{{ 'v2.7.1-20180130'.split('-')[0] }}"
-      BOX_VERSION: "{{ 'v2.7.1-20180130'.split('-')[1] }}"
+      CIRCLE_TAG: "v2.7.1-20180130"
     steps:
       - checkout
       - run: |
+          if [ ! -z "$CIRCLE_TAG" ]; then
+            echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)'" >> $BASH_ENV
+            echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
+          fi
+
+          . $BASH_ENV
+
           echo "ST2_VERSION=$ST2_VERSION"
           echo "BOX_VERSION=$BOX_VERSION"
           exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ _pin_version_on_release: &pin_version_on_release
       if [ ! -z "$CIRCLE_TAG" ]; then
         echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)')" >> $BASH_ENV
         echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
+        echo "Pinned ST2_VERSION=$ST2_VERSION and BOX_VERSION=$BOX_VERSION based on release CIRCLE_TAG=$CIRCLE_TAG"
+      else
+        echo '$CIRCLE_TAG is not set, - skipping a non release build ...'
       fi
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           export CIRCLE_TAG=v2.7.1-20180130
 
           if [ ! -z "$CIRCLE_TAG" ]; then
-            echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)'" >> $BASH_ENV
+            echo "export ST2_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=v)(\d+\.\d+\.\d+)(?=-\d{8}$)')" >> $BASH_ENV
             echo "export BOX_VERSION=$(echo $CIRCLE_TAG|grep -oP '(?<=\d-)\d{8}$')" >> $BASH_ENV
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Fix Vagrant Cloud deploy step, caused by wrong 'file not exist' error (#31)
 * Expose StackStorm Vagrant access via IP `10.10.10.10` (#29)
+* Extract from `CIRCLE_TAG` and pin `ST2_VERSION` & `BOX_VERSION` on release (#33)
 
 ## v2.7.1-20180511
 * Add continuous integration (#19)


### PR DESCRIPTION
Closes #30 

This will allow us to pin box/ova version correctly during the packer-st2 releases, instead of using latest versions.
