### PR TITLE
Add fallback port forwarding rule for accessing st2web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Add Vagrant port-forwarding rule to access st2web via `https://127.0.0.1:9000/` as a fallback (#36)
 
 ## v2.7.2-20180516
 * StackStorm 2.7.2 released

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -28,6 +28,13 @@ Vagrant.configure("2") do |config|
   # via 127.0.0.1 to disable public access
   # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
 
+  # Expose StackStorm Web UI via localhost:9000
+  # This is a fallback option to access the WebUI in case when "private_network" doesn't work
+  config.vm.network "forwarded_port",
+    guest: 443, host: 9000,
+    host_ip: "127.0.0.1", id: "st2web",
+    auto_correct: true
+
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network "private_network", ip: "192.168.33.10"


### PR DESCRIPTION
Closes StackStorm/st2docs#744

Add optional port forwarding rule for accessing st2web.
This is a fallback option to access the WebUI in case when "private_network" doesn't work for some reason like Virtualbox bug or similar.
