### PR TITLE
Change netmask to /30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## In Development
 
 
+## v2.7.2-20180614
+* Use /30 mask for private network (access via IP `10.10.10.10`). (#41)
+
 ## v2.7.2-20180523
 * Add Vagrant port-forwarding rule to access st2web via `https://127.0.0.1:9000/` as a fallback (#36)
 

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -42,7 +42,7 @@ Vagrant.configure("2") do |config|
   # Expose access to StackStorm via IP
   config.vm.network :private_network,
     ip: "10.10.10.10",
-    netmask: "255.255.255.254"
+    netmask: "255.255.255.252"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on


### PR DESCRIPTION
Change netmask to /30 on private network. Use of /31 does not work on some host OSes, e.g. macOS.

Fixes #40 