### PR TITLE
Ubuntu 16.04 LTS fixes for st2 v3.4

### DIFF
--- a/scripts/welcome.sh
+++ b/scripts/welcome.sh
@@ -7,9 +7,9 @@ echo 'StackStorm \n \l' > /etc/issue
 cat << 'EOF' > /etc/update-motd.d/00-header
 #!/bin/sh
 
-if [ -f /opt/stackstorm/st2/lib/python2.7/site-packages/st2common/__init__.py ]; then
+if [ -f /opt/stackstorm/st2/lib/python3.6/site-packages/st2common/__init__.py ]; then
   # Get st2 version based on hardcoded string in st2common
-  ST2_VERSION=$(python -c 'execfile("/opt/stackstorm/st2/lib/python2.7/site-packages/st2common/__init__.py"); print __version__')
+  ST2_VERSION=$(/opt/stackstorm/st2/bin/python -c 'exec(open("/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/__init__.py").read()); print(__version__)')
   printf "Welcome to \033[1;38;5;208mStackStorm\033[0m \033[1m%s\033[0m (Ubuntu 16.04 LTS %s %s)\n" "v${ST2_VERSION}" "$(uname -o)" "$(uname -m)"
 else
   printf "Welcome to \033[1;38;5;208mStackStorm\033[0m (Ubuntu 16.04 LTS %s %s)\n" "$(uname -o)" "$(uname -m)"

--- a/st2.json
+++ b/st2.json
@@ -36,7 +36,7 @@
       "type": "shell",
       "inline": [
         "echo '\\033[33mInstalling StackStorm v{{ user `st2_version` }} ...\\033[0m'",
-        "curl --retry 3 -fsSL https://stackstorm.com/packages/install.sh | bash -seu -- --user={{ user `st2_user` }} --password={{ user `st2_password` }} --version={{ user `st2_version` }}"
+        "curl --retry 3 -fsSL https://stackstorm.com/packages/install.sh | bash -seu -- --user={{ user `st2_user` }} --password={{ user `st2_password` }} --version={{ user `st2_version` }} --u16-add-insecure-py3-ppa"
       ]
     },
     {

--- a/test/integration/2-stackstorm/controls/services_test.rb
+++ b/test/integration/2-stackstorm/controls/services_test.rb
@@ -7,7 +7,7 @@
 ST2_SERVICES = %w(
   st2actionrunner st2api st2stream
   st2auth st2garbagecollector st2notifier
-  st2resultstracker st2rulesengine st2sensorcontainer
+  st2rulesengine st2sensorcontainer
   st2workflowengine st2timersengine
 ).freeze
 


### PR DESCRIPTION
Add the updated build instructions for U16 by providing `--u16-add-insecure-py3-ppa` to the curl|bash installer.

Once we deprecate Ubuntu Xenial, we'll need to switch to Ubuntu Bionic for building the Vagrant image: https://github.com/StackStorm/packer-st2/issues/47 (task assigned to `v3.5.0`).