### PR TITLE
Add a Changelog Reminder

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -6,7 +6,7 @@ on:
     branches:
     - main
     - master
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
 
 name: CI
 jobs:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+# GH Action notifies about the missing Changelog record for every PR
+# https://github.com/marketplace/actions/missing-changelog-reminder
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+name: Changelog Reminder
+jobs:
+  remind:
+    name: Changelog Reminder
+    runs-on: ubuntu-latest
+    # don't warn for a Draft PRs
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mskelton/changelog-reminder-action@v2
+        with:
+          message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](/CHANGELOG.md)!"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,10 +1,14 @@
-# GH Action notifies about the missing Changelog record for every PR
+# GH Action notifies PR author about the missing Changelog record
 # https://github.com/marketplace/actions/missing-changelog-reminder
 
 on:
   pull_request:
+    branches:
+    - main
+    - master
     types: [opened, synchronize, reopened, ready_for_review]
-name: Changelog Reminder
+
+name: CI
 jobs:
   remind:
     name: Changelog Reminder
@@ -15,4 +19,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mskelton/changelog-reminder-action@v2
         with:
-          message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](/CHANGELOG.md)!"
+          changelogRegex: "CHANGELOG\.md"
+          message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](./../blob/master/CHANGELOG.md)!"


### PR DESCRIPTION
GH Action notifies about the missing Changelog record for every PR
See: https://github.com/marketplace/actions/missing-changelog-reminder