### PR TITLE
Enable Changelog Reminder

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -16,5 +16,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mskelton/changelog-reminder-action@v2
         with:
-          changelogRegex: "CHANGELOG\.md"
           message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](./../blob/master/CHANGELOG.md)!"

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,23 @@
+# GH Action notifies PR author about the missing Changelog record
+# https://github.com/marketplace/actions/missing-changelog-reminder
+
+on:
+  pull_request:
+    branches:
+    - main
+    - master
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+
+name: CI
+jobs:
+  remind:
+    name: Changelog Reminder
+    runs-on: ubuntu-latest
+    # don't warn for a Draft PRs
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mskelton/changelog-reminder-action@v2
+        with:
+          changelogRegex: "CHANGELOG\.md"
+          message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](./../blob/master/CHANGELOG.md)!"

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -3,6 +3,8 @@
 
 on:
   pull_request:
+    branches:
+    - master
     types: [opened, synchronize, reopened, ready_for_review]
 
 name: CI

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
     - master
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
 
 name: CI
 jobs:

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -3,7 +3,7 @@
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 name: CI
 jobs:

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -18,4 +18,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mskelton/changelog-reminder-action@v2
         with:
+          changelogRegex: "CHANGELOG\\.md"
           message: "@${{ github.actor }} your pull request is missing a changelog. Please update the [CHANGELOG.md](./../blob/master/CHANGELOG.md)!"

--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -3,9 +3,6 @@
 
 on:
   pull_request:
-    branches:
-    - main
-    - master
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
 
 name: CI


### PR DESCRIPTION
GH Action notifies about the missing Changelog record for every PR
See: https://github.com/marketplace/actions/missing-changelog-reminder