### PR TITLE
Release v3.4.0-20210309

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,5 +1,6 @@
 # GH Action notifies PR author about the missing Changelog record
 # https://github.com/marketplace/actions/missing-changelog-reminder
+# NB! It doesn't work for the Forked PRs (More: https://github.com/peterjgrainger/action-changelog-reminder/issues/28)
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## In Development
 
+## v3.4.0-20210309
+* Switch to python3 for Ubuntu 16.04 LTS since st2 v3.4.0 (#55)
+* Remove deprecated `st2resultstracker` service (#55)
+
 ## v3.4.0-20210304
 * StackStorm 3.4.0 released
 


### PR DESCRIPTION
Release the fixed version of the Vagrant box following the https://github.com/StackStorm/packer-st2/pull/55 CI/CD fixes.