### PR TITLE
Upgrade to the latest ubuntu 18.04.6 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v3.6.0-20211120
 * StackStorm 3.6.0 released
+* Switch OS to Ubuntu Bionic `18.04.6` from `18.04.5`
 
 ## v3.5.0-20210628
 * StackStorm 3.5.0 released

--- a/st2.json
+++ b/st2.json
@@ -93,10 +93,10 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "https://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.5-server-amd64.iso"
+        "https://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.6-server-amd64.iso"
       ],
       "iso_checksum_type": "sha256",
-      "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+      "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,


### PR DESCRIPTION
The old images for 18.04.5 are no longer available. 