### PR TITLE
Update the Changelog.md for a v3.8.0-20230127 release

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -9,7 +9,7 @@ on:
       - synchronize
   push:
     branches:
-      - gha
+      - master
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## In Development
+
+## v3.8.0-20230127
 * Build Vagrant boxes with GitHub (#63)
 
 ## v3.8.0-20221126


### PR DESCRIPTION
Based on https://github.com/StackStorm/packer-st2/pull/64, let's do a release and push the latest box to Vagrant cloud.

Just a few final checks that I forgot:
- disconected CircleCI
- new branch protection rules
- missing master branch for the main build
- tag changelog for release